### PR TITLE
implement README parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,12 @@ For example:
 gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ```
 
+Do not set the Cloud Run region you'd like to deploy to through the `--region` flag in the `gcloud run` commands.
+Instead, as mentioned above, do so by setting the `run/region` gcloud property.
+
+In addition to setting a default Cloud Run region, make sure to deploy to the fully platform on Cloud Run. You can
+achieve this by setting the `run/platform` gcloud property to `managed` or passing in the `--platform=managed` flag
+to your `gcloud run` commands.
+
 If code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy your
 sample to Cloud Run based on whether your sample is java-based and doesn't have a Dockerfile or isn't.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ If you'd like, make sure to include the following comment code tag immediately p
 the program should build and deploy your sample:
 
 ```text
-[//]: # ({sst-run-linuxmacos})
+[//]: # ({sst-run-unix})
 ```
 
 For example:
 ````text
-[//]: # ({sst-run-linuxmacos})
+[//]: # ({sst-run-unix})
 ```
 gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ```

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 Do not set the Cloud Run region you'd like to deploy to through the `--region` flag in the `gcloud run` commands.
 Instead, as mentioned above, do so by setting the `run/region` gcloud property.
 
-In addition to setting a default Cloud Run region, make sure to deploy to the fully platform on Cloud Run. You can
-achieve this by setting the `run/platform` gcloud property to `managed` or passing in the `--platform=managed` flag
+In addition to setting a default Cloud Run region, make sure to deploy to the fully managed platform on Cloud Run. You
+can achieve this by setting the `run/platform` gcloud property to `managed` or passing in the `--platform=managed` flag
 to your `gcloud run` commands.
 
-If code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy your
-sample to Cloud Run based on whether your sample is java-based and doesn't have a Dockerfile or isn't.
+If comment code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy
+your sample to Cloud Run based on whether your sample is java-based and doesn't have a Dockerfile or isn't.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ If you'd like, make sure to include the following comment code tag immediately p
 the program should build and deploy your sample:
 
 ```text
-[//]: # ({t-run-linuxmacos})
+[//]: # ({sst-run-linuxmacos})
 ```
 
 For example:
 ````text
-[//]: # ({t-run-build-linuxmacos})
+[//]: # ({sst-run-build-linuxmacos})
 ```bash
 gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ```

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Make sure to authorize the gcloud SDK and set a default project and Cloud Run re
 default Cloud Run region can be set by setting the `run/region` gcloud property.
 
 ### README parsing
-If you'd like, make sure to include the following comment code tag immediately preceding code blocks to customize how
-the program should build and deploy your sample:
+If you'd like, make sure to include the following comment code tag in your README to customize how the program should
+build and deploy your sample:
 
 ```text
 [//]: # ({sst-run-unix})
@@ -43,6 +43,18 @@ For example:
 gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ```
 ````
+
+When parsing the README for custom build and deploy commands, the serverless sample tester will include any commands
+inside a code fence that is immediately preceded by a line containing `{sst-run-unix}`. You can use Markdown syntax
+(e.g. `[//]: # ({sst-run-unix})`) to include this line without making it visible when rendered.
+
+The parsed commands will not be run through a shell, meaning that the program will not perform any expansions,
+pipelines, redirections or any other functions that shells are responsible for. This also means that popular shell
+builtin commands like `cd`, `export`, and `echo` will not be available or may not work as expected.  
+
+However, any environment variables referenced in the form of `$var` or `${var}` will expanded. In addition, bash-style
+multiline commands (i.e. non-quoted backslashes at the end of a line that indicate a line continuation) will also be 
+supported. 
 
 Do not set the Cloud Run region you'd like to deploy to through the `--region` flag in the `gcloud run` commands.
 Instead, as mentioned above, do so by setting the `run/region` gcloud property.

--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ go build -o sst cmd/main.go
 ./sst [sample-dir]
 ```
 
-Make sure to authorize the gcloud SDK and set a default project before running this program.
+Make sure to authorize the gcloud SDK and set a default project and Cloud Run region before running this program. A
+default Cloud Run region can be set by setting the `run/region` gcloud property.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ the program should build and deploy your sample:
 For example:
 ````text
 [//]: # ({sst-run-linuxmacos})
-```bash
+```
 gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ```
+````
 
 Do not set the Cloud Run region you'd like to deploy to through the `--region` flag in the `gcloud run` commands.
 Instead, as mentioned above, do so by setting the `run/region` gcloud property.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the program should build and deploy your sample:
 
 For example:
 ````text
-[//]: # ({sst-run-build-linuxmacos})
+[//]: # ({sst-run-linuxmacos})
 ```bash
 gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ go build -o sst cmd/main.go
 
 Make sure to authorize the gcloud SDK and set a default project and Cloud Run region before running this program. A
 default Cloud Run region can be set by setting the `run/region` gcloud property.
+
+### README parsing
+If you'd like, make sure to include the following comment code tag immediately preceding code blocks to customize how
+the program should build and deploy your sample:
+
+```text
+[//]: # ({t-run-linuxmacos})
+```
+
+For example:
+````text
+[//]: # ({t-run-build-linuxmacos})
+```bash
+gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
+```
+
+If code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy your
+sample to Cloud Run based on whether your sample is java-based and doesn't have a Dockerfile or isn't.

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -60,7 +60,7 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 			return nil, fmt.Errorf("[lifecycle.NewLifecycle] parsing README.md: %w", err)
 		}
 
-		fmt.Printf("No code blocks immediately preceded by %s found in README.md", codeTag)
+		fmt.Printf("No code blocks immediately preceded by %s found in README.md\n", codeTag)
 	} else {
 		fmt.Println("No README.md found")
 	}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -47,10 +47,7 @@ func (l Lifecycle) Execute(commandsDir string) error {
 func NewLifecycle(sampleDir, serviceName, gcrURL string) Lifecycle {
 	readmePath := fmt.Sprintf("%s/README.md", sampleDir)
 
-	_, err := os.Stat(readmePath)
-	readmeExists := err == nil
-
-	if readmeExists {
+	if _, err := os.Stat(readmePath); err == nil {
 		lifecycle, err := parseREADME(readmePath, serviceName, gcrURL)
 		if err == nil {
 			log.Println("Using build and deploy commands found in README")
@@ -62,7 +59,7 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) Lifecycle {
 	pomPath := fmt.Sprintf("%s/pom.xml", sampleDir)
 	dockerfilePath := fmt.Sprintf("%s/Dockerfile", sampleDir)
 
-	_, err = os.Stat(pomPath)
+	_, err := os.Stat(pomPath)
 	pomExists := err == nil
 
 	_, err = os.Stat(dockerfilePath)

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -56,9 +56,11 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 			return lifecycle, nil
 		}
 
-		if !errors.Is(err, errNoREADMECommandsFound) {
-			return nil, fmt.Errorf("[lifecycle.NewLifecycle] parsing README.md: %v\n", err)
+		if !errors.Is(err, errNoREADMECodeBlocksFound) {
+			return nil, fmt.Errorf("[lifecycle.NewLifecycle] parsing README.md: %w", err)
 		}
+
+		fmt.Printf("No code blocks immediately preceded by %s found in README.md", codeTag)
 	} else {
 		fmt.Println("No README.md found")
 	}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -41,7 +41,6 @@ func (l Lifecycle) Execute(commandsDir string) error {
 	return nil
 }
 
-
 // NewLifecycle tries to parse the different options provided for build and deploy command configuration. If none of
 // those options are set up, it falls back to reasonable defaults based on whether the sample is java-based
 // (has a pom.xml) that doesn't have a Dockerfile or isn't.

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -52,10 +52,12 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) Lifecycle {
 	readmeExists := err == nil
 
 	if readmeExists {
-		if lifecycle, err := parseREADME(readmePath, serviceName, gcrURL); err == nil {
+		lifecycle, err := parseREADME(readmePath, serviceName, gcrURL)
+		if err == nil {
 			log.Println("Using build and deploy commands found in README")
 			return lifecycle
 		}
+		fmt.Printf("Failed parsing README: %v\n", err)
 	}
 
 	pomPath := fmt.Sprintf("%s/pom.xml", sampleDir)

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // Lifecycle is a list of ordered exec.Cmd that should be run to execute a certain process.
@@ -45,7 +46,7 @@ func (l Lifecycle) Execute(commandsDir string) error {
 // those options are set up, it falls back to reasonable defaults based on whether the sample is java-based
 // (has a pom.xml) that doesn't have a Dockerfile or isn't.
 func NewLifecycle(sampleDir, serviceName, gcrURL string) Lifecycle {
-	readmePath := fmt.Sprintf("%s/README.md", sampleDir)
+	readmePath := filepath.Join(sampleDir, "README.md")
 
 	if _, err := os.Stat(readmePath); err == nil {
 		lifecycle, err := parseREADME(readmePath, serviceName, gcrURL)
@@ -56,16 +57,16 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) Lifecycle {
 		fmt.Printf("Failed parsing README: %v\n", err)
 	}
 
-	pomPath := fmt.Sprintf("%s/pom.xml", sampleDir)
-	dockerfilePath := fmt.Sprintf("%s/Dockerfile", sampleDir)
+	pomPath := filepath.Join(sampleDir, "pom.xml")
+	dockerfilePath := filepath.Join(sampleDir, "Dockerfile")
 
 	_, err := os.Stat(pomPath)
-	pomExists := err == nil
+	pomE := err == nil
 
 	_, err = os.Stat(dockerfilePath)
-	dockerfileExists := err == nil
+	dockerfileE := err == nil
 
-	if pomExists && !dockerfileExists {
+	if pomE && !dockerfileE {
 		log.Println("Using default build and deploy commands for java samples without a Dockerfile")
 		return buildDefaultJavaLifecycle(serviceName, gcrURL)
 	}

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -120,10 +120,11 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 // It detects whether the command is a gcloud run command and replaces the last argument that isn't a flag
 // with the input service name.
 func replaceServiceName(command, serviceName string) string {
-	// regexp.MatchString only returns an error if there was an error compiling the provided regular expression pattern.
-	// Since we know both of the patterns we're providing are valid, ignore these errors.
-	containsGcloud, _ := regexp.MatchString(`\bgcloud\b`, command)
-	containsRun, _ := regexp.MatchString(`\brun\b`, command)
+	r1 := regexp.MustCompile(`\bgcloud\b`)
+	r2 := regexp.MustCompile(`\brun\b`)
+
+	containsGcloud := r1.MatchString(command)
+	containsRun := r2.MatchString(command)
 
 	if !(containsGcloud && containsRun) {
 		return command

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -42,7 +42,8 @@ var (
 
 	mdCodeFenceStartRegexp = regexp.MustCompile("^\\w*`{3,}[^`]*$")
 
-	errNoREADMECommandsFound = fmt.Errorf("[lifecycle.parseREADME]: no commands found")
+	errNoREADMECodeBlocksFound = fmt.Errorf("[lifecycle.parseREADME]: no code blocks immediately preceded by " +
+		"%s found", codeTag)
 )
 
 // parseREADME parses a README file with the given name. It reads terminal commands surrounded by one of the codeTags
@@ -61,14 +62,14 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 		return nil, fmt.Errorf("[lifecycle.parseREADME] extracting code blocks out of %s: %w", filename, err)
 	}
 
+	if len(codeBlocks) == 0 {
+		return nil, errNoREADMECodeBlocksFound
+	}
+
 	lifecycle, err := codeBlocksTolifecycle(codeBlocks, serviceName, gcrURL)
 	if err != nil {
 		return lifecycle, fmt.Errorf("[lifecycle.parseREADME] transforming code blocks in %s to executable "+
 			"commands: %w", filename, err)
-	}
-
-	if len(lifecycle) == 0 {
-		return lifecycle, errNoREADMECommandsFound
 	}
 
 	return lifecycle, nil

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -87,7 +87,7 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("[lifecycle.parseREADME] README bufio.Scanner: %w", err)
 	}
 
 	if len(lifecycle) == 0 {

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -1,0 +1,126 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/GoogleCloudPlatform/serverless-sample-tester/internal/util"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// The tag that should appear immediately before code blocks in a README to indicate that the enclosed commands
+// are to be used by this program for building and deploying the sample.
+var codeTag = "sst-run-linuxmacos"
+
+// parseREADME parses a README file with the given name. It reads terminal commands surrounded by one of the codeTags
+// listed above and loads them into a Lifecycle. In the process, it replaces the Cloud Run service name and Container
+// Registry tag with the provided inputs.
+func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	var lifecycle Lifecycle
+
+	inCode := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.Contains(line, "```") && inCode {
+			inCode = false
+		} else if strings.Contains(line, codeTag) {
+			scanner.Scan()
+			startCodeBlockLine := scanner.Text()
+
+			if !strings.Contains(startCodeBlockLine, "```") {
+				return nil, fmt.Errorf("error parsing README -- incorrect format")
+			}
+
+			inCode = true
+		} else if inCode {
+			for line[len(line)-1] == '\\' {
+				line = line[:len(line)-1]
+
+				scanner.Scan()
+				line = line + strings.TrimSpace(scanner.Text())
+			}
+
+			line = os.ExpandEnv(line)
+			line = replaceGCRURL(line, gcrURL)
+			line = replaceServiceName(line, serviceName)
+			sp := strings.Split(line, " ")
+
+			var cmd *exec.Cmd
+			if strings.Contains(line, "gcloud") {
+				cmd = util.GcloudCommandBuild(sp[1:]...)
+			} else {
+				cmd = exec.Command(sp[0], sp[1:]...)
+			}
+
+			lifecycle = append(lifecycle, cmd)
+		}
+	}
+
+	if inCode {
+		return nil, fmt.Errorf("error parsing README -- incorrect format")
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(lifecycle) == 0 {
+		return nil, fmt.Errorf("no commands found in README")
+	}
+
+	return lifecycle, nil
+}
+
+// replaceServiceName takes a terminal command string as input and replaces the Cloud Run service name, if any.
+// It detects whether the command is a gcloud run command and replaces the last argument that isn't a flag
+// with the input service name.
+func replaceServiceName(commandStr, serviceName string) string {
+	containsGcloud, _ := regexp.MatchString(`gcloud\b`, commandStr)
+	containsRun, _ := regexp.MatchString(`run\b`, commandStr)
+
+	if !(containsGcloud && containsRun) {
+		return commandStr
+	}
+
+	sp := strings.Split(commandStr, " ")
+	for i := len(sp) - 1; i >= 0; i-- {
+		if !strings.Contains(sp[i], "--") {
+			sp[i] = serviceName
+			break
+		}
+	}
+
+	return strings.Join(sp, " ")
+}
+
+// replaceServiceName takes a terminal command string as input and replaces the URL of a container image stored in the
+// GCP Container Registry with the given URL.
+func replaceGCRURL(commandStr string, gcrURL string) string {
+	re := regexp.MustCompile(`gcr.io/.+/\S+`)
+	return re.ReplaceAllString(commandStr, gcrURL)
+}

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -34,7 +34,7 @@ var codeTag = "sst-run-linuxmacos"
 func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("[lifecycle.parseREADME] os.Open %s: %w", filename, err)
 	}
 	defer file.Close()
 

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -26,7 +26,7 @@ import (
 
 // The tag that should appear immediately before code blocks in a README to indicate that the enclosed commands
 // are to be used by this program for building and deploying the sample.
-var codeTag = "sst-run-linuxmacos"
+var codeTag = "sst-run-unix"
 
 // parseREADME parses a README file with the given name. It reads terminal commands surrounded by one of the codeTags
 // listed above and loads them into a Lifecycle. In the process, it replaces the Cloud Run service name and Container

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -26,7 +26,7 @@ import (
 
 // The tag that should appear immediately before code blocks in a README to indicate that the enclosed commands
 // are to be used by this program for building and deploying the sample.
-var codeTag = "sst-run-unix"
+var codeTag = "{sst-run-unix}"
 
 // parseREADME parses a README file with the given name. It reads terminal commands surrounded by one of the codeTags
 // listed above and loads them into a Lifecycle. In the process, it replaces the Cloud Run service name and Container

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -120,12 +120,12 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 
 	var l Lifecycle
 	for _, b := range codeBlocks {
-		c, err := b.toCommands(serviceName, gcrURL)
+		cmds, err := b.toCommands(serviceName, gcrURL)
 		if err != nil {
 			return l, fmt.Errorf("[lifecycle.parseREADME] transforming code blocks in %s to executable commands: %w", filename, err)
 		}
 
-		l = append(l, c...)
+		l = append(l, cmds...)
 	}
 
 	return l, nil

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -42,8 +42,7 @@ var (
 
 	mdCodeFenceStartRegexp = regexp.MustCompile("^\\w*`{3,}[^`]*$")
 
-	errNoREADMECodeBlocksFound = fmt.Errorf("[lifecycle.parseREADME]: no code blocks immediately preceded by " +
-		"%s found", codeTag)
+	errNoREADMECodeBlocksFound = fmt.Errorf("[lifecycle.parseREADME]: no code blocks immediately preceded by %s found", codeTag)
 )
 
 // parseREADME parses a README file with the given name. It reads terminal commands surrounded by one of the codeTags
@@ -68,8 +67,7 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 
 	lifecycle, err := codeBlocksTolifecycle(codeBlocks, serviceName, gcrURL)
 	if err != nil {
-		return lifecycle, fmt.Errorf("[lifecycle.parseREADME] transforming code blocks in %s to executable "+
-			"commands: %w", filename, err)
+		return lifecycle, fmt.Errorf("[lifecycle.parseREADME] transforming code blocks in %s to executable commands: %w", filename, err)
 	}
 
 	return lifecycle, nil
@@ -86,18 +84,16 @@ func codeBlocks(scanner *bufio.Scanner) ([][]string, error) {
 
 		if strings.Contains(line, codeTag) {
 			if s := scanner.Scan(); !s {
-				if err := scanner.Err(); err != nil && !s {
+				if err := scanner.Err(); err != nil {
 					return nil, fmt.Errorf("[lifecycle.codeBlocks] bufio.Scanner: %w", err)
 				}
-				return nil, fmt.Errorf("[lifecycle.codeBlocks]: unexpected EOF; file ended immediately " +
-					"after code tag")
+				return nil, fmt.Errorf("[lifecycle.codeBlocks]: unexpected EOF; file ended immediately after code tag")
 			}
 
 			startCodeBlockLine := scanner.Text()
 			m := mdCodeFenceStartRegexp.MatchString(startCodeBlockLine)
 			if !m {
-				return nil, fmt.Errorf("[lifecycle.codeBlocks]: expecting start of code block immediately " +
-					"after code tag")
+				return nil, fmt.Errorf("[lifecycle.codeBlocks]: expecting start of code block immediately after code tag")
 			}
 
 			c := strings.Count(startCodeBlockLine, "`")
@@ -154,8 +150,7 @@ func codeBlocksTolifecycle(codeBlocks [][]string, serviceName, gcrURL string) (L
 
 				i++
 				if i >= len(block) {
-					return nil, fmt.Errorf("[lifecycle.codeBlocksTolifecycle]: unexpected end of code block; " +
-						"expecting command line continuation")
+					return nil, fmt.Errorf("[lifecycle.codeBlocksTolifecycle]: unexpected end of code block; expecting command line continuation")
 				}
 
 				l := block[i]
@@ -172,7 +167,7 @@ func codeBlocksTolifecycle(codeBlocks [][]string, serviceName, gcrURL string) (L
 			sp := strings.Split(line, " ")
 
 			var cmd *exec.Cmd
-			if strings.Contains(line, "gcloud") {
+			if sp[0] == "gcloud" {
 				a := append(util.GcloudCommonFlags, sp[1:]...)
 				cmd = exec.Command("gcloud", a...)
 			} else {

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -100,15 +100,15 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 // replaceServiceName takes a terminal command string as input and replaces the Cloud Run service name, if any.
 // It detects whether the command is a gcloud run command and replaces the last argument that isn't a flag
 // with the input service name.
-func replaceServiceName(commandStr, serviceName string) string {
-	containsGcloud, _ := regexp.MatchString(`\bgcloud\b`, commandStr)
-	containsRun, _ := regexp.MatchString(`\brun\b`, commandStr)
+func replaceServiceName(command, serviceName string) string {
+	containsGcloud, _ := regexp.MatchString(`\bgcloud\b`, command)
+	containsRun, _ := regexp.MatchString(`\brun\b`, command)
 
 	if !(containsGcloud && containsRun) {
-		return commandStr
+		return command
 	}
 
-	sp := strings.Split(commandStr, " ")
+	sp := strings.Split(command, " ")
 	for i := len(sp) - 1; i >= 0; i-- {
 		if !strings.Contains(sp[i], "--") {
 			sp[i] = serviceName
@@ -121,7 +121,7 @@ func replaceServiceName(commandStr, serviceName string) string {
 
 // replaceGCRURL takes a terminal command string as input and replaces the URL of a container image stored in the
 // GCP Container Registry with the given URL.
-func replaceGCRURL(commandStr string, gcrURL string) string {
+func replaceGCRURL(command string, gcrURL string) string {
 	re := regexp.MustCompile(`gcr.io/.+/\S+`)
-	return re.ReplaceAllString(commandStr, gcrURL)
+	return re.ReplaceAllString(command, gcrURL)
 }

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -66,7 +66,10 @@ func NewSample(dir string) (*Sample, error) {
 	}
 	service := gcloud.CloudRunService{Name: serviceName}
 
-	buildDeployLifecycle := lifecycle.NewLifecycle(dir, service.Name, cloudContainerImageURL)
+	buildDeployLifecycle, err := lifecycle.NewLifecycle(dir, service.Name, cloudContainerImageURL)
+	if err != nil {
+		return nil, fmt.Errorf("[sample.NewSample] getting Lifecycle: %w", err)
+	}
 
 	s := &Sample{
 		Name:                   name,


### PR DESCRIPTION
This PR implements functionality to parse terminal commands for building and deploying a sample to the Cloud Run fully managed platform out of the sample's README.md. Code blocks that include commands that the serverless-sample-tester would like to run should be immediately preceded with a comment including the tag `sst-run-linuxmacos`. For example:

````text
[//]: # ({sst-run-linuxmacos})
```bash
gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
```
````

This PR does **not** include:
-  Revised algorithm to replace Cloud Run service names in parsed terminal commands.
-  Customizable Cloud Run region and revised hierarchy for customization of Cloud Run region.

These changes will be made in (a) separate PR(s).