### PR TITLE
refactor error messages (fixes #4)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,10 +22,12 @@ import (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "sst [sample-dir]",
-		Short: "An end-to-end tester for GCP samples",
-		Args:  cobra.ExactArgs(1),
-		RunE:  cmd.Root,
+		Use:           "sst [sample-dir]",
+		Short:         "An end-to-end tester for GCP samples",
+		Args:          cobra.ExactArgs(1),
+		RunE:          cmd.Root,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -51,7 +51,7 @@ func Root(cmd *cobra.Command, args []string) error {
 	defer s.Service.Delete(s.Dir)
 	defer s.DeleteCloudContainerImage()
 	if err != nil {
-		return fmt.Errorf("[cmd.Root] building and deploying sample to Cloud Run: %w", err)
+		return fmt.Errorf("Lifecycle.Execute building and deploying sample to Cloud Run: %w", err)
 	}
 
 	log.Println("Getting identity token for gcloud auhtorized account")
@@ -61,19 +61,19 @@ func Root(cmd *cobra.Command, args []string) error {
 	identToken, err = util.ExecCommand(exec.Command("gcloud", a...), s.Dir)
 
 	if err != nil {
-		return fmt.Errorf("[cmd.Root] getting identity token for gcloud auhtorized account: %w", err)
+		return fmt.Errorf("util.ExecCommand getting identity token for gcloud auhtorized account: %w", err)
 	}
 
 	log.Println("Checking endpoints for expected results")
 	serviceURL, err := s.Service.URL(s.Dir)
 	if err != nil {
-		return fmt.Errorf("[cmd.Root] getting Cloud Run service URL: %w", err)
+		return fmt.Errorf("Service.URL %s dir: %w", s.Dir, err)
 	}
 
 	log.Println("Validating Cloud Run service endpoints for expected status codes")
 	allTestsPassed, err := util.ValidateEndpoints(serviceURL, &swagger.Paths, identToken)
 	if err != nil {
-		return fmt.Errorf("[cmd.Root] validating Cloud Run service endpoints for expected status codes: %w", err)
+		return fmt.Errorf("util.ValidateEndpoints: %w", err)
 	}
 
 	if !allTestsPassed {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -51,7 +51,7 @@ func Root(cmd *cobra.Command, args []string) error {
 	defer s.Service.Delete(s.Dir)
 	defer s.DeleteCloudContainerImage()
 	if err != nil {
-		return fmt.Errorf("Lifecycle.Execute building and deploying sample to Cloud Run: %w", err)
+		return fmt.Errorf("Lifecycle.Execute: building and deploying sample to Cloud Run: %w", err)
 	}
 
 	log.Println("Getting identity token for gcloud auhtorized account")
@@ -61,13 +61,13 @@ func Root(cmd *cobra.Command, args []string) error {
 	identToken, err = util.ExecCommand(exec.Command("gcloud", a...), s.Dir)
 
 	if err != nil {
-		return fmt.Errorf("util.ExecCommand getting identity token for gcloud auhtorized account: %w", err)
+		return fmt.Errorf("getting identity token for gcloud auhtorized account: %w", err)
 	}
 
 	log.Println("Checking endpoints for expected results")
 	serviceURL, err := s.Service.URL(s.Dir)
 	if err != nil {
-		return fmt.Errorf("Service.URL %s dir: %w", s.Dir, err)
+		return fmt.Errorf("Service.URL: %s dir: %w", s.Dir, err)
 	}
 
 	log.Println("Validating Cloud Run service endpoints for expected status codes")

--- a/internal/gcloud/cloud_run_service.go
+++ b/internal/gcloud/cloud_run_service.go
@@ -41,7 +41,7 @@ func (s CloudRunService) Delete(sampleDir string) error {
 	_, err := util.ExecCommand(exec.Command("gcloud", a...), sampleDir)
 
 	if err != nil {
-		return fmt.Errorf("[CloudRunService.delete] deleting Cloud Run Service: %w", err)
+		return fmt.Errorf("util.ExecCommand deleting Cloud Run Service: %w", err)
 	}
 
 	return nil
@@ -59,7 +59,7 @@ func (s *CloudRunService) URL(sampleDir string) (string, error) {
 	url, err := util.ExecCommand(exec.Command("gcloud", a...), sampleDir)
 
 	if err != nil {
-		return "", fmt.Errorf("[CloudRunService.URL] getting Cloud Run Service URL: %w", err)
+		return "", fmt.Errorf("util.ExecCommand getting Cloud Run Service URL: %w", err)
 	}
 
 	s.url = url
@@ -73,7 +73,7 @@ func ServiceName(sampleName string) (string, error) {
 
 	_, err := rand.Read(randBytes)
 	if err != nil {
-		return "", fmt.Errorf("[gcloud.ServiceName] getting crypto/rand bytes: %w", err)
+		return "", fmt.Errorf("crypto/rand.Read: %w", err)
 	}
 
 	randSuffix := hex.EncodeToString(randBytes)

--- a/internal/gcloud/cloud_run_service.go
+++ b/internal/gcloud/cloud_run_service.go
@@ -41,7 +41,7 @@ func (s CloudRunService) Delete(sampleDir string) error {
 	_, err := util.ExecCommand(exec.Command("gcloud", a...), sampleDir)
 
 	if err != nil {
-		return fmt.Errorf("util.ExecCommand deleting Cloud Run Service: %w", err)
+		return fmt.Errorf("deleting Cloud Run Service: %w", err)
 	}
 
 	return nil
@@ -59,7 +59,7 @@ func (s *CloudRunService) URL(sampleDir string) (string, error) {
 	url, err := util.ExecCommand(exec.Command("gcloud", a...), sampleDir)
 
 	if err != nil {
-		return "", fmt.Errorf("util.ExecCommand getting Cloud Run Service URL: %w", err)
+		return "", fmt.Errorf("getting Cloud Run Service URL: %w", err)
 	}
 
 	s.url = url

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -37,7 +37,7 @@ func (l Lifecycle) Execute(commandsDir string) error {
 
 		_, err := util.ExecCommand(c, commandsDir)
 		if err != nil {
-			return fmt.Errorf("util.ExecCommand executing lifecycle command: %w", err)
+			return fmt.Errorf("executing Lifecycle command: %w", err)
 		}
 	}
 
@@ -70,7 +70,7 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 		}
 
 		if !errors.Is(err, errNoREADMECodeBlocksFound) {
-			return nil, fmt.Errorf("lifecycle.parseREADME %s: %w", readmePath, err)
+			return nil, fmt.Errorf("lifecycle.parseREADME: %s: %w", readmePath, err)
 		}
 
 		log.Println("No code blocks immediately preceded by %s found in README.md\n", codeTag)

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -37,7 +37,7 @@ func (l Lifecycle) Execute(commandsDir string) error {
 
 		_, err := util.ExecCommand(c, commandsDir)
 		if err != nil {
-			return fmt.Errorf("[Lifecycle.Execute] executing lifecycle command: %w", err)
+			return fmt.Errorf("util.ExecCommand executing lifecycle command: %w", err)
 		}
 	}
 
@@ -70,7 +70,7 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 		}
 
 		if !errors.Is(err, errNoREADMECodeBlocksFound) {
-			return nil, fmt.Errorf("[lifecycle.NewLifecycle] parsing README.md: %w", err)
+			return nil, fmt.Errorf("lifecycle.parseREADME %s: %w", readmePath, err)
 		}
 
 		log.Println("No code blocks immediately preceded by %s found in README.md\n", codeTag)

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -45,12 +45,9 @@ var (
 	errNoREADMECodeBlocksFound = fmt.Errorf("lifecycle.extractCodeBlocks: no code blocks immediately preceded by %s found", codeTag)
 )
 
-// codeBlock is a struct holding a slice of strings containing terminal commands found in a Markdown file's code blocks.
-// It also contains the line number of the Markdown file where the code portion of the code block starts.
-type codeBlock struct {
-	lines        []string
-	startLineNum int
-}
+// codeBlock is a slice of strings containing terminal commands. codeBlocks, for example, could be used to hold the
+// terminal commands inside of a Markdown code block.
+type codeBlock []string
 
 // toCommands extracts the terminal commands contained within the current codeBlock. It handles the expansion of
 // environment variables and line continuations. It also detects Cloud Run service names Google Container Registry
@@ -58,9 +55,8 @@ type codeBlock struct {
 func (cb codeBlock) toCommands(serviceName, gcrURL string) ([]*exec.Cmd, error) {
 	var cmds []*exec.Cmd
 
-	startLineNum := cb.startLineNum
-	for i := 0; i < len(cb.lines); i++ {
-		line := cb.lines[i]
+	for i := 0; i < len(cb); i++ {
+		line := cb[i]
 		if line == "" {
 			continue
 		}
@@ -71,11 +67,11 @@ func (cb codeBlock) toCommands(serviceName, gcrURL string) ([]*exec.Cmd, error) 
 			line = line[:len(line)-1]
 
 			i++
-			if i >= len(cb.lines) {
-				return nil, fmt.Errorf("line %d: unexpected end of code block; expecting command line continuation", startLineNum+1)
+			if i >= len(cb) {
+				return nil, fmt.Errorf("unexpected end of code block: expecting command line continuation; code block dump:\n%s", strings.Join(cb, "\n"))
 			}
 
-			l := cb.lines[i]
+			l := cb[i]
 			if l == "" {
 				break
 			}
@@ -164,7 +160,7 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 			c := strings.Count(startCodeBlockLine, "`")
 			mdCodeFenceEndRegexp := regexp.MustCompile(fmt.Sprintf("^\\w*`{%d,}\\w*$", c))
 
-			block := codeBlock{startLineNum: lineNum + 1}
+			var block codeBlock
 			var blockClosed bool
 			for scanner.Scan() {
 				lineNum++
@@ -174,7 +170,7 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 					break
 				}
 
-				block.lines = append(block.lines, line)
+				block = append(block, line)
 			}
 
 			if err := scanner.Err(); err != nil {

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -42,7 +42,7 @@ var (
 
 	mdCodeFenceStartRegexp = regexp.MustCompile("^\\w*`{3,}[^`]*$")
 
-	errNoREADMECodeBlocksFound = fmt.Errorf("lifecycle.extractCodeBlocks no code blocks immediately preceded by %s found", codeTag)
+	errNoREADMECodeBlocksFound = fmt.Errorf("lifecycle.extractCodeBlocks: no code blocks immediately preceded by %s found", codeTag)
 )
 
 // codeBlock is a slice of strings containing terminal commands. codeBlocks, for example, could be used to hold the
@@ -104,14 +104,14 @@ func (cb codeBlock) toCommands(serviceName, gcrURL string) ([]*exec.Cmd, error) 
 func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, fmt.Errorf("os.Open %s: %w", filename, err)
+		return nil, fmt.Errorf("os.Open: %w", err)
 	}
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	codeBlocks, err := extractCodeBlocks(scanner)
 	if err != nil {
-		return nil, fmt.Errorf("lifecycle.extractCodeBlocks %s: %w", filename, err)
+		return nil, fmt.Errorf("lifecycle.extractCodeBlocks: %s: %w", filename, err)
 	}
 
 	if len(codeBlocks) == 0 {
@@ -122,7 +122,7 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 	for _, b := range codeBlocks {
 		cmds, err := b.toCommands(serviceName, gcrURL)
 		if err != nil {
-			return l, fmt.Errorf("codeBlock.toCommands code blocks in %s: %w", filename, err)
+			return l, fmt.Errorf("codeBlock.toCommands: code blocks in %s: %w", filename, err)
 		}
 
 		l = append(l, cmds...)

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -42,7 +42,7 @@ var (
 
 	mdCodeFenceStartRegexp = regexp.MustCompile("^\\w*`{3,}[^`]*$")
 
-	errNoREADMECodeBlocksFound = fmt.Errorf("[lifecycle.parseREADME]: no code blocks immediately preceded by %s found", codeTag)
+	errNoREADMECodeBlocksFound = fmt.Errorf("lifecycle.extractCodeBlocks no code blocks immediately preceded by %s found", codeTag)
 )
 
 // codeBlock is a slice of strings containing terminal commands. codeBlocks, for example, could be used to hold the
@@ -68,7 +68,7 @@ func (cb codeBlock) toCommands(serviceName, gcrURL string) ([]*exec.Cmd, error) 
 
 			i++
 			if i >= len(cb) {
-				return nil, fmt.Errorf("[lifecycle.codeBlocksTolifecycle]: unexpected end of code block; expecting command line continuation")
+				return nil, fmt.Errorf("unexpected end of code block; expecting command line continuation")
 			}
 
 			l := cb[i]
@@ -104,14 +104,14 @@ func (cb codeBlock) toCommands(serviceName, gcrURL string) ([]*exec.Cmd, error) 
 func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, fmt.Errorf("[lifecycle.parseREADME] os.Open %s: %w", filename, err)
+		return nil, fmt.Errorf("os.Open %s: %w", filename, err)
 	}
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 	codeBlocks, err := extractCodeBlocks(scanner)
 	if err != nil {
-		return nil, fmt.Errorf("[lifecycle.parseREADME] extracting code blocks out of %s: %w", filename, err)
+		return nil, fmt.Errorf("lifecycle.extractCodeBlocks %s: %w", filename, err)
 	}
 
 	if len(codeBlocks) == 0 {
@@ -122,7 +122,7 @@ func parseREADME(filename, serviceName, gcrURL string) (Lifecycle, error) {
 	for _, b := range codeBlocks {
 		cmds, err := b.toCommands(serviceName, gcrURL)
 		if err != nil {
-			return l, fmt.Errorf("[lifecycle.parseREADME] transforming code blocks in %s to executable commands: %w", filename, err)
+			return l, fmt.Errorf("codeBlock.toCommands code blocks in %s: %w", filename, err)
 		}
 
 		l = append(l, cmds...)
@@ -143,15 +143,15 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 		if strings.Contains(line, codeTag) {
 			if s := scanner.Scan(); !s {
 				if err := scanner.Err(); err != nil {
-					return nil, fmt.Errorf("[lifecycle.codeBlocks] bufio.Scanner: %w", err)
+					return nil, fmt.Errorf("bufio.Scanner.Scan: %w", err)
 				}
-				return nil, fmt.Errorf("[lifecycle.codeBlocks]: unexpected EOF; file ended immediately after code tag")
+				return nil, fmt.Errorf("unexpected EOF: file ended immediately after code tag")
 			}
 
 			startCodeBlockLine := scanner.Text()
 			m := mdCodeFenceStartRegexp.MatchString(startCodeBlockLine)
 			if !m {
-				return nil, fmt.Errorf("[lifecycle.codeBlocks]: expecting start of code block immediately after code tag")
+				return nil, fmt.Errorf("expecting start of code block immediately after code tag")
 			}
 
 			c := strings.Count(startCodeBlockLine, "`")
@@ -170,11 +170,11 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 			}
 
 			if err := scanner.Err(); err != nil {
-				return nil, fmt.Errorf("[lifecycle.codeBlocks] bufio.Scanner: %w", err)
+				return nil, fmt.Errorf("bufio.Scanner.Scan: %w", err)
 			}
 
 			if !blockClosed {
-				return nil, fmt.Errorf("[lifecycle.codeBlocks]: unexpected EOF; code block not closed")
+				return nil, fmt.Errorf("unexpected EOF: code block not closed")
 			}
 
 			blocks = append(blocks, block)
@@ -182,7 +182,7 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("[lifecycle.codeBlocks] bufio.Scanner: %w", err)
+		return nil, fmt.Errorf("bufio.Scanner.Scan: %w", err)
 	}
 
 	return blocks, nil

--- a/internal/lifecycle/readme.go
+++ b/internal/lifecycle/readme.go
@@ -145,7 +145,7 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 		if strings.Contains(line, codeTag) {
 			if s := scanner.Scan(); !s {
 				if err := scanner.Err(); err != nil {
-					return nil, fmt.Errorf("bufio.Scanner.Scan: %w", err)
+					return nil, fmt.Errorf("line %d: bufio.Scanner.Scan: %w", lineNum, err)
 				}
 				return nil, fmt.Errorf("unexpected EOF: file ended immediately after code tag")
 			}
@@ -174,7 +174,7 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 			}
 
 			if err := scanner.Err(); err != nil {
-				return nil, fmt.Errorf("bufio.Scanner.Scan: %w", err)
+				return nil, fmt.Errorf("line %d: bufio.Scanner.Scan: %w", lineNum, err)
 			}
 
 			if !blockClosed {
@@ -186,7 +186,7 @@ func extractCodeBlocks(scanner *bufio.Scanner) ([]codeBlock, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("bufio.Scanner.Scan: %w", err)
+		return nil, fmt.Errorf("line %d: bufio.Scanner.Scan: %w", lineNum, err)
 	}
 
 	return blocks, nil

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -49,26 +49,26 @@ func NewSample(dir string) (*Sample, error) {
 
 	containerTag, err := cloudContainerImageTag(name, dir)
 	if err != nil {
-		return nil, fmt.Errorf("[sample.NewSample] generating Container Registry container image tag: %w", err)
+		return nil, fmt.Errorf("cloudContainerImageTag %s %s: %w", name, dir, err)
 	}
 
 	a := append(util.GcloudCommonFlags, "config", "get-value", "core/project")
 	projectID, err := util.ExecCommand(exec.Command("gcloud", a...), dir)
 
 	if err != nil {
-		return nil, fmt.Errorf("[sample.NewSample] getting gcloud default project: %w", err)
+		return nil, fmt.Errorf("util.ExecCommand getting gcloud default project: %w", err)
 	}
 	cloudContainerImageURL := fmt.Sprintf("gcr.io/%s/%s", projectID, containerTag)
 
 	serviceName, err := gcloud.ServiceName(name)
 	if err != nil {
-		return nil, fmt.Errorf("[sample.NewSample] generating Cloud Run Service name: %w", err)
+		return nil, fmt.Errorf("gcloud.ServiceName %s sample: %w", name, err)
 	}
 	service := gcloud.CloudRunService{Name: serviceName}
 
 	buildDeployLifecycle, err := lifecycle.NewLifecycle(dir, service.Name, cloudContainerImageURL)
 	if err != nil {
-		return nil, fmt.Errorf("[sample.NewSample] getting Lifecycle: %w", err)
+		return nil, fmt.Errorf("lifecycle.NewLifecycle: %w", err)
 	}
 
 	s := &Sample{
@@ -95,7 +95,7 @@ func (s *Sample) DeleteCloudContainerImage() error {
 	_, err := util.ExecCommand(exec.Command("gcloud", a...), s.Dir)
 
 	if err != nil {
-		return fmt.Errorf("[Sample.DeleteCloudContainerImage] deleting Container Registry container image: %w", err)
+		return fmt.Errorf("util.ExecCommand deleting Container Registry container image: %w", err)
 	}
 
 	return nil
@@ -106,7 +106,7 @@ func (s *Sample) DeleteCloudContainerImage() error {
 func cloudContainerImageTag(sampleName string, sampleDir string) (string, error) {
 	sha, err := util.ExecCommand(exec.Command("git", "rev-parse", "--verify", "--short", "HEAD"), sampleDir)
 	if err != nil {
-		return "", fmt.Errorf("[sample.cloudContainerImageTag] getting short SHA for sample repository: %w", err)
+		return "", fmt.Errorf("util.ExecCommand getting short SHA for sample repository: %w", err)
 	}
 
 	l := maxCloudContainerImageTagLen - len(sha) - 1

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -49,20 +49,20 @@ func NewSample(dir string) (*Sample, error) {
 
 	containerTag, err := cloudContainerImageTag(name, dir)
 	if err != nil {
-		return nil, fmt.Errorf("cloudContainerImageTag %s %s: %w", name, dir, err)
+		return nil, fmt.Errorf("sample.cloudContainerImageTag: %s %s: %w", name, dir, err)
 	}
 
 	a := append(util.GcloudCommonFlags, "config", "get-value", "core/project")
 	projectID, err := util.ExecCommand(exec.Command("gcloud", a...), dir)
 
 	if err != nil {
-		return nil, fmt.Errorf("util.ExecCommand getting gcloud default project: %w", err)
+		return nil, fmt.Errorf("getting gcloud default project: %w", err)
 	}
 	cloudContainerImageURL := fmt.Sprintf("gcr.io/%s/%s", projectID, containerTag)
 
 	serviceName, err := gcloud.ServiceName(name)
 	if err != nil {
-		return nil, fmt.Errorf("gcloud.ServiceName %s sample: %w", name, err)
+		return nil, fmt.Errorf("gcloud.ServiceName: %s sample: %w", name, err)
 	}
 	service := gcloud.CloudRunService{Name: serviceName}
 
@@ -95,7 +95,7 @@ func (s *Sample) DeleteCloudContainerImage() error {
 	_, err := util.ExecCommand(exec.Command("gcloud", a...), s.Dir)
 
 	if err != nil {
-		return fmt.Errorf("util.ExecCommand deleting Container Registry container image: %w", err)
+		return fmt.Errorf("deleting Container Registry container image: %w", err)
 	}
 
 	return nil
@@ -106,7 +106,7 @@ func (s *Sample) DeleteCloudContainerImage() error {
 func cloudContainerImageTag(sampleName string, sampleDir string) (string, error) {
 	sha, err := util.ExecCommand(exec.Command("git", "rev-parse", "--verify", "--short", "HEAD"), sampleDir)
 	if err != nil {
-		return "", fmt.Errorf("util.ExecCommand getting short SHA for sample repository: %w", err)
+		return "", fmt.Errorf("getting short SHA for sample repository: %w", err)
 	}
 
 	l := maxCloudContainerImageTagLen - len(sha) - 1

--- a/internal/util/command.go
+++ b/internal/util/command.go
@@ -47,7 +47,7 @@ func ExecCommand(cmd *exec.Cmd, dir string) (string, error) {
 	err := cmd.Run()
 	if err != nil {
 		out := strings.TrimSpace(string(stdcombined.Bytes()))
-		return "", fmt.Errorf("[util.ExecCommand] error executing external command %v:\n%s\n%w", cmd, out, err)
+		return "", fmt.Errorf("exec.Cmd.Run %v:\n%s\n%w", cmd, out, err)
 	}
 
 	out := strings.TrimSpace(string(stdout.Bytes()))

--- a/internal/util/command.go
+++ b/internal/util/command.go
@@ -47,7 +47,7 @@ func ExecCommand(cmd *exec.Cmd, dir string) (string, error) {
 	err := cmd.Run()
 	if err != nil {
 		out := strings.TrimSpace(string(stdcombined.Bytes()))
-		return "", fmt.Errorf("exec.Cmd.Run %v:\n%s\n%w", cmd, out, err)
+		return "", fmt.Errorf("exec.Cmd.Run: %v:\n%s\n%w", cmd, out, err)
 	}
 
 	out := strings.TrimSpace(string(stdout.Bytes()))

--- a/internal/util/endpoints.go
+++ b/internal/util/endpoints.go
@@ -53,7 +53,7 @@ func ValidateEndpoints(serviceURL string, paths *openapi3.Paths, identityToken s
 		for _, t := range tests {
 			s, err := validateEndpointOperation(endpointURL, t.operation, t.httpMethod, identityToken)
 			if err != nil {
-				return s, fmt.Errorf("util.validateEndpointOperation testing %s requests on %s: %w", t.httpMethod, endpointURL, err)
+				return s, fmt.Errorf("util.validateEndpointOperation: testing %s requests on %s: %w", t.httpMethod, endpointURL, err)
 			}
 
 			success = s && success
@@ -77,7 +77,7 @@ func validateEndpointOperation(endpointURL string, operation *openapi3.Operation
 
 		s, err := makeTestRequest(endpointURL, httpMethod, "", reqBodyReader, operation, identityToken)
 		if err != nil {
-			return s, fmt.Errorf("util.makeTestRequest testing %s request on %s: %w", httpMethod, endpointURL, err)
+			return s, fmt.Errorf("util.makeTestRequest: testing %s request on %s: %w", httpMethod, endpointURL, err)
 		}
 
 		return s, nil
@@ -93,7 +93,7 @@ func validateEndpointOperation(endpointURL string, operation *openapi3.Operation
 
 		s, err := makeTestRequest(endpointURL, httpMethod, mimeType, reqBodyReader, operation, identityToken)
 		if err != nil {
-			return s, fmt.Errorf("util.makeTestRequest testing %s %s request on %s: %w", httpMethod, mimeType, endpointURL, err)
+			return s, fmt.Errorf("util.makeTestRequest: testing %s %s request on %s: %w", httpMethod, mimeType, endpointURL, err)
 		}
 
 		allTestsPassed = allTestsPassed && s
@@ -109,7 +109,7 @@ func makeTestRequest(endpointURL, httpMethod, mimeType string, reqBodyReader *st
 
 	req, err := http.NewRequest(httpMethod, endpointURL, reqBodyReader)
 	if err != nil {
-		return false, fmt.Errorf("http.NewRequest creating an http.Request: %w", err)
+		return false, fmt.Errorf("http.NewRequest: %w", err)
 	}
 
 	req.Header.Add("Authorization", "Bearer "+identityToken)
@@ -123,7 +123,7 @@ func makeTestRequest(endpointURL, httpMethod, mimeType string, reqBodyReader *st
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return false, fmt.Errorf("ioutil.ReadAll http.Response.Body: %w", err)
+		return false, fmt.Errorf("ioutil.ReadAll: reading http.Response.Body: %w", err)
 	}
 
 	statusCode := strconv.Itoa(resp.StatusCode)

--- a/internal/util/endpoints.go
+++ b/internal/util/endpoints.go
@@ -123,7 +123,7 @@ func makeTestRequest(endpointURL, httpMethod, mimeType string, reqBodyReader *st
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return false, fmt.Errorf("ioutil.ReadAll response body: %w", err)
+		return false, fmt.Errorf("ioutil.ReadAll http.Response.Body: %w", err)
 	}
 
 	statusCode := strconv.Itoa(resp.StatusCode)

--- a/internal/util/endpoints.go
+++ b/internal/util/endpoints.go
@@ -53,7 +53,7 @@ func ValidateEndpoints(serviceURL string, paths *openapi3.Paths, identityToken s
 		for _, t := range tests {
 			s, err := validateEndpointOperation(endpointURL, t.operation, t.httpMethod, identityToken)
 			if err != nil {
-				return s, fmt.Errorf("[util.ValidateEndpoints] testing %s requests on %s: %w", t.httpMethod, endpointURL, err)
+				return s, fmt.Errorf("util.validateEndpointOperation testing %s requests on %s: %w", t.httpMethod, endpointURL, err)
 			}
 
 			success = s && success
@@ -77,7 +77,7 @@ func validateEndpointOperation(endpointURL string, operation *openapi3.Operation
 
 		s, err := makeTestRequest(endpointURL, httpMethod, "", reqBodyReader, operation, identityToken)
 		if err != nil {
-			return s, fmt.Errorf("[util.validateEndpointOperation] testing %s request on %s: %w", httpMethod, endpointURL, err)
+			return s, fmt.Errorf("util.makeTestRequest testing %s request on %s: %w", httpMethod, endpointURL, err)
 		}
 
 		return s, nil
@@ -93,7 +93,7 @@ func validateEndpointOperation(endpointURL string, operation *openapi3.Operation
 
 		s, err := makeTestRequest(endpointURL, httpMethod, mimeType, reqBodyReader, operation, identityToken)
 		if err != nil {
-			return s, fmt.Errorf("[util.validateEndpointOperation] testing %s %s request on %s: %w", httpMethod, mimeType, endpointURL, err)
+			return s, fmt.Errorf("util.makeTestRequest testing %s %s request on %s: %w", httpMethod, mimeType, endpointURL, err)
 		}
 
 		allTestsPassed = allTestsPassed && s
@@ -109,7 +109,7 @@ func makeTestRequest(endpointURL, httpMethod, mimeType string, reqBodyReader *st
 
 	req, err := http.NewRequest(httpMethod, endpointURL, reqBodyReader)
 	if err != nil {
-		return false, fmt.Errorf("[util.makeTestRequest] creating an http.Request: %w", err)
+		return false, fmt.Errorf("http.NewRequest creating an http.Request: %w", err)
 	}
 
 	req.Header.Add("Authorization", "Bearer "+identityToken)
@@ -117,13 +117,13 @@ func makeTestRequest(endpointURL, httpMethod, mimeType string, reqBodyReader *st
 
 	resp, err := (*client).Do(req)
 	if err != nil {
-		return false, fmt.Errorf("[util.makeTestRequest]: creating executing a http.Request: %w", err)
+		return false, fmt.Errorf("http.Client.Do: %w", err)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return false, fmt.Errorf("[util.makeTestRequest]: reading http.Response: %w", err)
+		return false, fmt.Errorf("ioutil.ReadAll response body: %w", err)
 	}
 
 	statusCode := strconv.Itoa(resp.StatusCode)


### PR DESCRIPTION
This PR fixes issue #4.

- Include callee function rather than caller functions
- Add more error context in some cases

Update error message format from:
```
if err != nil {
    fmt.Errorf("[{package/struct name}.{current function name}] {what we were trying to do}: %w", err)
}
```

To:
```
if err != nil {
    fmt.Errorf("{package/struct name}.{callee function name} {what we were trying to do}: %w", err)
}
```

Will rebase and update once PR #22 is merged. 