### PR TITLE
fix default build mechanism priority for jib (address #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,9 @@ then `$CLOUD_RUN_SERVICE_NAME` should be set to `run-mysql`.
 
 ### Defaults
 If comment code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy
-your sample to Cloud Run based on whether your sample is Java-based (has a `pom.xml` in its root directory) or not.
+your sample to Cloud Run based on whether your sample is Java-based (has a pom.xml) or not.
+
+If your sample is Java-based, your sample will be built and pushed to the Container Registry using `mvn compile com.google.cloud.tools:jib-maven-plugin:2.0.0:build -Dimage=tag`.
+Otherwise, your sample will be built and pushed to the Container Registry using `gcloud builds submit --tag=[tag]`. 
+
+In both cases, `gcloud run deploy` will be used to deploy the container image to Cloud Run.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ your sample to Cloud Run based on whether your sample is Java-based (has a pom.x
 If your sample is Java-based, your sample will be built and pushed to the Container Registry using
 `mvn compile com.google.cloud.tools:jib-maven-plugin:2.0.0:build -Dimage=[image_tag]`.
 
-Otherwise, your sample will be build and pushed to the Container Registry using
+Otherwise, your sample will be built and pushed to the Container Registry using
 `gcloud builds submit --tag=[image_tag]`.
 
 In both cases, `gcloud run deploy --image=[image_tag] --platform=managed`, will be used to deploy the container image to

--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ then `$CLOUD_RUN_SERVICE_NAME` should be set to `run-mysql`.
 If comment code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy
 your sample to Cloud Run based on whether your sample is Java-based (has a pom.xml) or not.
 
-If your sample is Java-based, your sample will be built and pushed to the Container Registry using `mvn compile com.google.cloud.tools:jib-maven-plugin:2.0.0:build -Dimage=tag`.
-Otherwise, your sample will be built and pushed to the Container Registry using `gcloud builds submit --tag=[tag]`. 
+If your sample is Java-based, your sample will be built and pushed to the Container Registry using
+`mvn compile com.google.cloud.tools:jib-maven-plugin:2.0.0:build -Dimage=[image_tag]`.
 
-In both cases, `gcloud run deploy` will be used to deploy the container image to Cloud Run.
+Otherwise, your sample will be build and pushed to the Container Registry using
+`gcloud builds submit --tag=[image_tag]`.
+
+In both cases, `gcloud run deploy --image=[image_tag] --platform=managed`, will be used to deploy the container image to
+Cloud Run.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Authenticate gcloud with your user account:
 gcloud auth login
 ```
 
-Consider setting defaults for Cloud Run operations, such as setting the region:
+Set defaults for Cloud Run operations, such as setting the region:
 ```bash
 gcloud config set run/region us-central1
 gcloud config set run/platform managed
@@ -33,6 +33,14 @@ Run Serverless Sample Tester by passing in the root directory of the sample you 
 ```bash
 ./sst [target-dir]
 ```
+
+## Build and Deploying Your Sample
+This program allows you to specify how you would like it to build and deploy your sample to Cloud Run, fully managed,
+in two ways. From highest to lowest, this program uses the following precedence order to find your build and deploy
+instructions:
+
+1. README parsing
+1. Defaults
 
 ### README parsing
 To parse build and deploy commands from your sample's README, include the following comment code tag before each gcloud command:
@@ -50,9 +58,9 @@ gcloud builds submit --tag=gcr.io/${GOOGLE_CLOUD_PROJECT}/run-mysql
 ````
 In the absence of a README, the tool will fall back on reasonable defaults based on whether the sample is Java-based and/or has a Dockerfile.
 
-## Configuration and Implementation
+#### Configuration and Implementation
 
-### README location
+#### README location
 For parsing the README, the tool assumes that it is located in the target directory. If you wish to parse a README file located elsewhere, you can include the README's location
 in a `config.yaml` file in the target directory, using the key `readme`. You can specify an absolute directory, or you can simply
 specify a directory relative to the sample's directory.
@@ -62,7 +70,7 @@ For example, if the README is in the parent directory of the sample:
 readme: ../README.md
 ```
 
-### Parsing rules
+#### Parsing rules
 No parsed commands are run through a shell, meaning that the tool will not perform any typical expansions, pipelines, redirections, or other functions. This also means that popular shell builtin commands like `cd`, `export`, `echo`, and
 others may not work as expected.
 
@@ -79,3 +87,8 @@ what the name is, but it may not always be accurate. For example, if your README
 gcloud run deploy run-mysql --image gcr.io/[YOUR_PROJECT_ID]/run-mysql
 ```
 then `$CLOUD_RUN_SERVICE_NAME` should be set to `run-mysql`.
+
+
+### Defaults
+If comment code tags aren't added to your README, the program will fall back to reasonable defaults to build and deploy
+your sample to Cloud Run based on whether your sample is Java-based (has a `pom.xml` in its root directory) or not.

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -45,7 +45,7 @@ func (l Lifecycle) Execute(commandsDir string) error {
 }
 
 // NewLifecycle tries to parse the different options provided for build and deploy command configuration. If none of
-// those options are set up, it falls back to reasonable defaults based on whether the sample is java-based
+// those options are set up, it falls back to reasonable defaults based on whether the sample is Java-based
 // (has a pom.xml) or not.
 func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 	var readmePath string
@@ -81,11 +81,11 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 	pomE := err == nil
 
 	if pomE {
-		log.Println("Using default build and deploy commands for java samples")
+		log.Println("Using default build and deploy commands for Java samples")
 		return buildDefaultJavaLifecycle(serviceName, gcrURL), nil
 	}
 
-	log.Println("Using default build and deploy commands for non-java samples")
+	log.Println("Using default build and deploy commands for non-Java samples")
 	return buildDefaultLifecycle(serviceName, gcrURL), nil
 }
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -46,7 +46,7 @@ func (l Lifecycle) Execute(commandsDir string) error {
 
 // NewLifecycle tries to parse the different options provided for build and deploy command configuration. If none of
 // those options are set up, it falls back to reasonable defaults based on whether the sample is java-based
-// (has a pom.xml) that doesn't have a Dockerfile or isn't.
+// (has a pom.xml) or not.
 func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 	var readmePath string
 	// Searching for config file
@@ -77,20 +77,15 @@ func NewLifecycle(sampleDir, serviceName, gcrURL string) (Lifecycle, error) {
 	}
 
 	pomPath := filepath.Join(sampleDir, "pom.xml")
-	dockerfilePath := filepath.Join(sampleDir, "Dockerfile")
-
 	_, err := os.Stat(pomPath)
 	pomE := err == nil
 
-	_, err = os.Stat(dockerfilePath)
-	dockerfileE := err == nil
-
-	if pomE && !dockerfileE {
-		log.Println("Using default build and deploy commands for java samples without a Dockerfile")
+	if pomE {
+		log.Println("Using default build and deploy commands for java samples")
 		return buildDefaultJavaLifecycle(serviceName, gcrURL), nil
 	}
 
-	log.Println("Using default build and deploy commands for non-java samples or java samples with a Dockerfile")
+	log.Println("Using default build and deploy commands for non-java samples")
 	return buildDefaultLifecycle(serviceName, gcrURL), nil
 }
 


### PR DESCRIPTION
This PR addresses issue #7 in part.

For all Java-based samples (`pom.xml` in the sample's root directory), we're going to use Jib, regardless of whether or not the sample also has a `Dockerfile` included in its root directory.

If we want, we can also include a `—no-jib` flag here that would force the program to use `gcloud builds submit` for all samples.